### PR TITLE
Specify package files in 'dependencies' in MLHUB.yaml

### DIFF
--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -13,6 +13,7 @@ meta:
 dependencies:
   system : atril
   cran   : rpart, magrittr, rpart.plot, RColorBrewer, rattle, ggplot2, randomForest, scales, stringi
+  files  : demo.R, print.R, README.md
 commands:
   demo  : Step through alternative options for barcharts.
   print : Display the code used for the demo.


### PR DESCRIPTION
Package file specification is now available at mlhubber/mlhub@f21a442